### PR TITLE
Fix CMake Xlib DisplayServer name.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -34,7 +34,7 @@ elseif(CMAKE_SYSTEM_NAME STREQUAL "Linux")
 
     if (BUILD_WSI_XLIB_SUPPORT)
         add_definitions(-DVK_USE_PLATFORM_XLIB_KHR)
-        set(DisplayServer XLib)
+        set(DisplayServer Xlib)
     endif()
 
     if (BUILD_WSI_WAYLAND_SUPPORT)


### PR DESCRIPTION
The DisplayServer name for Xlib was incorrectly set to XLib which did not match other references
in the build scripts. This has been fixed which fixes the build for XLib support.
